### PR TITLE
Feat: Implement BFT Consensus Logic - Phase 1

### DIFF
--- a/testnet/src/consensus/bft.rs
+++ b/testnet/src/consensus/bft.rs
@@ -57,3 +57,231 @@ pub struct SignedMessage<T> {
     pub signer_pubkey: [u8; 32], // The public key of the signer (validator)
     pub signature: [u8; 64],     // The signature over the (serialized) message
 }
+
+use std::collections::BTreeMap;
+
+/// Holds the state for a BFT consensus instance.
+#[derive(Debug, Clone)]
+pub struct BftState {
+    pub current_round: u64,
+    pub current_leader_pubkey: [u8; 32], // For simplicity, can be fixed or passed in
+    pub quorum_threshold: usize, // e.g., 15 for 15/21
+
+    // Key: (item_hash, round) -> Vec of signed votes for that item in that round
+    pub prepare_votes: BTreeMap<([u8; 32], u64), Vec<SignedMessage<VoteMessage>>>,
+    pub precommit_votes: BTreeMap<([u8; 32], u64), Vec<SignedMessage<VoteMessage>>>,
+    pub commit_votes: BTreeMap<([u8; 32], u64), Vec<SignedMessage<VoteMessage>>>,
+
+    // Key: (item_hash, round) -> QC for that item, formed in that round
+    // Alternatively, could be BTreeMap<[u8;32], QuorumCertificate> if only one QC per item_hash is stored,
+    // but HotStuff can have QCs for different rounds for the same item (though typically for different items/blocks).
+    // Let's stick to (item_hash, round) for now for flexibility.
+    pub known_qcs: BTreeMap<([u8; 32], u64), QuorumCertificate>,
+
+    // Local node's public key, useful for leader checks.
+    // This might be part of a larger NodeContext struct in a full implementation.
+    pub local_node_pubkey: [u8; 32],
+}
+
+impl BftState {
+    pub fn new(
+        initial_round: u64,
+        leader_pubkey: [u8; 32],
+        quorum_threshold: usize,
+        local_node_pubkey: [u8; 32]
+    ) -> Self {
+        BftState {
+            current_round: initial_round,
+            current_leader_pubkey: leader_pubkey,
+            quorum_threshold,
+            prepare_votes: BTreeMap::new(),
+            precommit_votes: BTreeMap::new(),
+            commit_votes: BTreeMap::new(),
+            known_qcs: BTreeMap::new(),
+            local_node_pubkey,
+        }
+    }
+
+    // Placeholder for methods to be implemented in subsequent steps
+    // pub fn generate_proposal(...)
+    // pub fn generate_vote(...)
+    // pub fn process_signed_vote(...)
+
+    /// Generates a new TriadProposal if the current node is the leader for the current round.
+    ///
+    /// # Arguments
+    /// * `parent_qc`: The QuorumCertificate justifying the parent state this proposal extends.
+    /// * `new_proposed_header`: The TriadHeader for the new Triad being proposed.
+    ///   The caller is responsible for ensuring this header is valid and correctly
+    ///   links to the parent state certified by `parent_qc` (i.e.,
+    ///   `new_proposed_header.parent_hash == parent_qc.certified_item_hash`).
+    ///
+    /// # Returns
+    /// `Some(TriadProposal)` if the current node is the leader, `None` otherwise.
+    pub fn generate_proposal(
+        &self,
+        parent_qc: QuorumCertificate, // The QC for the parent this proposal extends
+        new_proposed_header: TriadHeader, // The header for the new triad/block
+    ) -> Option<TriadProposal> {
+        if self.local_node_pubkey != self.current_leader_pubkey {
+            return None; // Not the leader for the current round
+        }
+
+        // Basic sanity check: the new header should correctly point to the parent certified by the QC.
+        // This check might be more involved in a full system (e.g. checking QC's round vs proposal round).
+        if new_proposed_header.parent_hash != parent_qc.certified_item_hash {
+            // This indicates a misbehaving proposer or incorrect input from the application layer.
+            // In a real system, this might log an error or panic depending on trust assumptions.
+            // For now, let's prevent creating an invalid proposal.
+            // Or, this responsibility could be solely on the caller.
+            // For robustness of BftState, a check is good.
+            // Consider returning Result<TriadProposal, Error> if more error states are needed.
+            // For now, returning None if inputs are inconsistent.
+            // TODO: Log this inconsistency if a logging mechanism is added.
+            return None;
+        }
+
+        // TODO: Further validation of parent_qc itself (e.g., signatures, round progression)
+        // For now, we assume parent_qc is validly formed.
+
+        Some(TriadProposal {
+            round: self.current_round,
+            proposer_pubkey: self.local_node_pubkey,
+            proposed_triad_header: new_proposed_header,
+            parent_qc,
+        })
+    }
+
+    /// Validates a given proposal and generates a vote if validation passes.
+    ///
+    /// # Arguments
+    /// * `proposal`: The `TriadProposal` to validate and vote on.
+    /// * `vote_type`: The type of vote to generate (e.g., Prepare, Precommit).
+    ///
+    /// # Returns
+    /// `Some(VoteMessage)` if the proposal is valid and a vote is generated,
+    /// `None` otherwise.
+    pub fn generate_vote(
+        &self,
+        proposal: &TriadProposal,
+        vote_type: VoteType,
+    ) -> Option<VoteMessage> {
+        // 1. Basic Round Check: Proposal should be for the current round.
+        //    (HotStuff has more complex round synchronization, this is simplified).
+        if proposal.round != self.current_round {
+            // TODO: Log "Proposal for wrong round"
+            return None;
+        }
+
+        // 2. Parent QC Validation (Simplified):
+        //    - Check if the parent QC's round is less than the proposal's round.
+        //    - Check if the parent QC's certified item hash matches the proposal's parent hash.
+        //    A full implementation would verify signatures in parent_qc and check against known state.
+        if proposal.parent_qc.round >= proposal.round {
+            // TODO: Log "Parent QC round not less than proposal round"
+            return None;
+        }
+        if proposal.proposed_triad_header.parent_hash != proposal.parent_qc.certified_item_hash {
+            // This should also be caught by generate_proposal, but good to double check as a voter.
+            // TODO: Log "Proposal parent hash mismatch with parent QC"
+            return None;
+        }
+        // TODO: Check if proposal.parent_qc is actually known/valid (e.g., in self.known_qcs).
+        //       For now, we assume it's structurally okay if passed basic checks.
+
+        // 3. Proposal Content Validation (Placeholder for future checks):
+        //    - Is proposed_triad_header internally consistent?
+        //    - Are transactions valid (if they were part of the proposal explicitly)?
+        //    - Does the proposal extend the state correctly from parent_qc? (Requires state access)
+        //    For now, these are skipped.
+
+        // If all checks pass (for this simplified phase):
+        let voted_item_hash = proposal.proposed_triad_header.hash();
+
+        Some(VoteMessage {
+            vote_type,
+            round: proposal.round, // Or self.current_round, should be the same here
+            voted_item_hash,
+        })
+    }
+
+    /// Processes a signed vote message. Stores the vote, checks for quorum,
+    /// and forms a QuorumCertificate (QC) if quorum is met.
+    ///
+    /// # Arguments
+    /// * `signed_vote`: The `SignedMessage<VoteMessage>` received from a validator.
+    ///
+    /// # Returns
+    /// `Some(QuorumCertificate)` if a new QC is formed, `None` otherwise.
+    ///
+    /// TODO:
+    ///  - Implement actual signature verification.
+    ///  - Add protection against duplicate votes from the same validator for the same item/round/type.
+    ///  - More robust validation of the vote's content against current BFT state.
+    pub fn process_signed_vote(
+        &mut self,
+        signed_vote: SignedMessage<VoteMessage>,
+    ) -> Option<QuorumCertificate> {
+        let vote_msg = &signed_vote.message;
+
+        // 1. Basic Vote Validation (Simplified)
+        if vote_msg.round != self.current_round {
+            // TODO: Log "Vote for wrong round" or handle out-of-round votes (e.g., for catch-up)
+            return None;
+        }
+        // TODO: Validate that signed_vote.signer_pubkey is a known validator.
+        // TODO: Verify signature signed_vote.signature over serialized vote_msg.message.
+
+        let votes_map_key = (vote_msg.voted_item_hash, vote_msg.round);
+
+        // Get the appropriate vote list based on vote_type
+        let current_vote_list = match vote_msg.vote_type {
+            VoteType::Prepare => self.prepare_votes.entry(votes_map_key).or_insert_with(Vec::new),
+            VoteType::Precommit => self.precommit_votes.entry(votes_map_key).or_insert_with(Vec::new),
+            VoteType::Commit => self.commit_votes.entry(votes_map_key).or_insert_with(Vec::new),
+        };
+
+        // Check for duplicate vote from the same signer for this specific item, round, and type
+        if current_vote_list.iter().any(|sv| sv.signer_pubkey == signed_vote.signer_pubkey) {
+            // TODO: Log "Duplicate vote received"
+            return None; // Already have a vote from this signer for this item/round/type
+        }
+
+        current_vote_list.push(signed_vote.clone()); // Store the clone of the signed vote
+
+        // 3. Check for Quorum
+        if current_vote_list.len() >= self.quorum_threshold {
+            // Quorum met, form a QC
+            let signatures_for_qc: Vec<([u8; 32], [u8; 64])> = current_vote_list
+                .iter()
+                // Take up to quorum_threshold signatures, though in practice it might be exactly that many
+                // if we stop processing once QC is formed, or more if votes arrive concurrently.
+                // For simplicity, let's just take all we have if it's >= threshold.
+                // A real implementation might be more specific about which ones form the "first" QC.
+                .map(|sv| (sv.signer_pubkey, sv.signature))
+                .collect();
+
+            let new_qc = QuorumCertificate {
+                vote_type: vote_msg.vote_type, // The type of votes this QC is for
+                round: vote_msg.round,
+                certified_item_hash: vote_msg.voted_item_hash,
+                signatures: signatures_for_qc,
+            };
+
+            // Store and return the new QC
+            // Note: This might overwrite an existing QC if one was somehow formed earlier for the exact same item/round.
+            // This simple implementation assumes one QC per (item, round, vote_type leading to QC).
+            // HotStuff typically has one QC per (view/round) for a specific proposal that gained traction.
+            // The key for known_qcs might need refinement based on how QCs are used (e.g. just item_hash if round is implicit in state machine).
+            // For now (item_hash, round) is used as key for known_qcs.
+            self.known_qcs.insert(votes_map_key, new_qc.clone());
+
+            // TODO: Potentially clean up the vote list now that a QC has been formed,
+            // or leave them for audit/later inspection. For now, leave them.
+
+            return Some(new_qc);
+        }
+
+        None // No new QC formed yet
+    }
+}

--- a/testnet/src/consensus/bft_test.rs
+++ b/testnet/src/consensus/bft_test.rs
@@ -113,4 +113,175 @@ mod tests {
         assert_eq!(signed_vote_msg.message.round, 3);
         assert_eq!(signed_vote_msg.signer_pubkey[0], 4);
     }
+
+    // --- Tests for BftState methods ---
+
+    // Helper to create a default BftState for testing
+    fn default_bft_state(local_pk: [u8; 32], leader_pk: [u8; 32], quorum: usize) -> crate::consensus::bft::BftState {
+        crate::consensus::bft::BftState::new(1, leader_pk, quorum, local_pk)
+    }
+
+    // Helper to create a TriadHeader with a specific parent hash
+    fn header_for_parent(parent_hash: [u8; 32], level: u64, position: &str) -> TriadHeader {
+        TriadHeader {
+            level,
+            position: position.to_string(),
+            position_hash: blake3_hash(position.as_bytes()),
+            parent_hash, // Set explicitly
+            tx_root: dummy_item_hash(level as u8), // Some dummy hash
+            state_root: dummy_item_hash(level as u8 + 100), // Some dummy hash
+            tx_count: 0,
+            max_capacity: (1000.0 * (1.0 + 0.004 * level as f64)) as u16,
+            split_nonce: 0,
+            timestamp: 1234567890 + level as i64,
+            validator_sigs: [None; 15],
+        }
+    }
+
+
+    #[test]
+    fn test_bft_state_generate_proposal() {
+        let leader_pk = dummy_pubkey(1);
+        let non_leader_pk = dummy_pubkey(2);
+        let quorum = 2; // For simple 2 out of 3 tests later perhaps
+
+        let mut state_leader = default_bft_state(leader_pk, leader_pk, quorum);
+        state_leader.current_round = 5;
+
+        let mut state_non_leader = default_bft_state(non_leader_pk, leader_pk, quorum);
+        state_non_leader.current_round = 5;
+
+        let parent_certified_hash = dummy_item_hash(10);
+        let parent_qc = QuorumCertificate {
+            vote_type: VoteType::Commit, // QC from previous round's commit
+            round: 4,
+            certified_item_hash: parent_certified_hash,
+            signatures: vec![(dummy_pubkey(100), dummy_signature(100))], // Dummy signature
+        };
+
+        let valid_new_header = header_for_parent(parent_certified_hash, 1, "pos_A");
+        let invalid_new_header = header_for_parent(dummy_item_hash(11), 1, "pos_B"); // Wrong parent hash
+
+        // Leader generates proposal successfully
+        let proposal_opt = state_leader.generate_proposal(parent_qc.clone(), valid_new_header.clone());
+        assert!(proposal_opt.is_some());
+        let proposal = proposal_opt.unwrap();
+        assert_eq!(proposal.round, 5);
+        assert_eq!(proposal.proposer_pubkey, leader_pk);
+        assert_eq!(proposal.proposed_triad_header.level, valid_new_header.level); // Check header content
+        assert_eq!(proposal.parent_qc.round, parent_qc.round);
+
+        // Non-leader attempts to generate proposal
+        let non_leader_proposal_opt = state_non_leader.generate_proposal(parent_qc.clone(), valid_new_header.clone());
+        assert!(non_leader_proposal_opt.is_none(), "Non-leader should not generate proposal");
+
+        // Leader attempts to generate proposal with inconsistent header (parent_hash mismatch)
+        let inconsistent_proposal_opt = state_leader.generate_proposal(parent_qc.clone(), invalid_new_header.clone());
+        assert!(inconsistent_proposal_opt.is_none(), "Proposal with inconsistent parent hash should fail");
+    }
+
+    #[test]
+    fn test_bft_state_generate_vote() {
+        let validator_pk = dummy_pubkey(1);
+        let leader_pk = dummy_pubkey(2); // Different from validator for this test
+        let quorum = 2;
+        let mut state = default_bft_state(validator_pk, leader_pk, quorum);
+        state.current_round = 1;
+
+        let parent_hash_val = dummy_item_hash(20);
+        let parent_qc = QuorumCertificate {
+            vote_type: VoteType::Commit,
+            round: 0, // Parent QC from previous round
+            certified_item_hash: parent_hash_val,
+            signatures: vec![], // Dummy
+        };
+
+        let proposed_header = header_for_parent(parent_hash_val, 1, "prop_pos_1");
+        let valid_proposal = TriadProposal {
+            round: 1, // Matches current round
+            proposer_pubkey: leader_pk,
+            proposed_triad_header: proposed_header.clone(),
+            parent_qc: parent_qc.clone(),
+        };
+
+        // Valid proposal -> should generate vote
+        let vote_opt = state.generate_vote(&valid_proposal, VoteType::Prepare);
+        assert!(vote_opt.is_some());
+        let vote = vote_opt.unwrap();
+        assert_eq!(vote.vote_type, VoteType::Prepare);
+        assert_eq!(vote.round, 1);
+        assert_eq!(vote.voted_item_hash, proposed_header.hash());
+
+        // Invalid: Proposal for wrong round
+        let wrong_round_proposal = TriadProposal { round: 2, ..valid_proposal.clone() };
+        assert!(state.generate_vote(&wrong_round_proposal, VoteType::Prepare).is_none());
+
+        // Invalid: Parent QC round not less than proposal round
+        let bad_parent_qc_round = QuorumCertificate { round: 1, ..parent_qc.clone() };
+        let bad_parent_qc_proposal = TriadProposal { parent_qc: bad_parent_qc_round, ..valid_proposal.clone() };
+        assert!(state.generate_vote(&bad_parent_qc_proposal, VoteType::Prepare).is_none());
+
+        // Invalid: Proposal parent hash mismatch with parent QC
+        let mismatched_header = header_for_parent(dummy_item_hash(21), 1, "mismatch_pos"); // Different parent hash
+        let bad_proposal_parent_hash = TriadProposal { proposed_triad_header: mismatched_header, ..valid_proposal.clone() };
+        assert!(state.generate_vote(&bad_proposal_parent_hash, VoteType::Prepare).is_none());
+    }
+
+    #[test]
+    fn test_bft_state_process_signed_vote_and_qc_formation() {
+        let leader_pk = dummy_pubkey(1);
+        let validator1_pk = dummy_pubkey(10);
+        let validator2_pk = dummy_pubkey(11);
+        // let validator3_pk = dummy_pubkey(12); // Unused, quorum is 2
+        let quorum = 2; // Quorum of 2 votes needed
+
+        let mut state = default_bft_state(leader_pk, leader_pk, quorum); // local_node is leader
+        state.current_round = 1;
+
+        let item_hash_to_vote_on = dummy_item_hash(30);
+
+        // Create and process first vote (Prepare)
+        let vote1_msg = VoteMessage { vote_type: VoteType::Prepare, round: 1, voted_item_hash: item_hash_to_vote_on };
+        let signed_vote1 = SignedMessage { message: vote1_msg, signer_pubkey: validator1_pk, signature: dummy_signature(10) };
+        let qc_opt1 = state.process_signed_vote(signed_vote1.clone());
+        assert!(qc_opt1.is_none(), "QC should not form with only 1 vote");
+        assert_eq!(state.prepare_votes.get(&(item_hash_to_vote_on, 1)).unwrap().len(), 1);
+
+        // Process duplicate vote from validator1 - should be ignored
+        let qc_opt_dup = state.process_signed_vote(signed_vote1.clone()); // Same signed vote
+        assert!(qc_opt_dup.is_none(), "QC should not form from duplicate vote");
+        assert_eq!(state.prepare_votes.get(&(item_hash_to_vote_on, 1)).unwrap().len(), 1, "Duplicate vote should not be added");
+
+        // Create and process second vote from a different validator (Prepare)
+        let vote2_msg = VoteMessage { vote_type: VoteType::Prepare, round: 1, voted_item_hash: item_hash_to_vote_on };
+        let signed_vote2 = SignedMessage { message: vote2_msg, signer_pubkey: validator2_pk, signature: dummy_signature(11) };
+        let qc_opt2 = state.process_signed_vote(signed_vote2.clone());
+
+        assert!(qc_opt2.is_some(), "QC should form when quorum (2) is met for Prepare votes");
+        let qc = qc_opt2.unwrap();
+        assert_eq!(qc.vote_type, VoteType::Prepare);
+        assert_eq!(qc.round, 1);
+        assert_eq!(qc.certified_item_hash, item_hash_to_vote_on);
+        assert_eq!(qc.signatures.len(), 2); // Contains sigs from validator1 and validator2
+        assert!(qc.signatures.contains(&(validator1_pk, dummy_signature(10))));
+        assert!(qc.signatures.contains(&(validator2_pk, dummy_signature(11))));
+
+        // Check if QC is stored in known_qcs
+        assert!(state.known_qcs.contains_key(&(item_hash_to_vote_on, 1)));
+
+        // Process a third vote (should not form a new QC for the same item/round/type if one already formed,
+        // but current impl might just add to list and re-form if list grows.
+        // Let's assume it just adds to the list for now, the QC is formed once threshold is met).
+        // The test above already confirmed QC formation.
+        // A more robust check would be that process_signed_vote doesn't return Some(QC) again for the same (item,round,type)
+        // if a QC was already formed and returned. Our current BftState.known_qcs keying might need adjustment for this.
+        // For now, let's test that a vote for a different round or item doesn't interfere.
+
+        let item_hash_other = dummy_item_hash(31);
+        let vote_other_item_msg = VoteMessage { vote_type: VoteType::Prepare, round: 1, voted_item_hash: item_hash_other };
+        let signed_vote_other_item = SignedMessage { message: vote_other_item_msg, signer_pubkey: validator1_pk, signature: dummy_signature(10) };
+        let qc_opt_other = state.process_signed_vote(signed_vote_other_item);
+        assert!(qc_opt_other.is_none(), "QC should not form for a different item with only 1 vote");
+        assert_eq!(state.prepare_votes.get(&(item_hash_other, 1)).unwrap().len(), 1);
+    }
 }

--- a/testnet/src/triad/structs.rs
+++ b/testnet/src/triad/structs.rs
@@ -33,6 +33,11 @@ impl TriadHeader {
         bytes.extend(self.timestamp.to_be_bytes());
         bytes
     }
+
+    /// Computes the hash of the TriadHeader using its canonical encoding.
+    pub fn hash(&self) -> [u8; 32] {
+        blake3_hash(&self.canonical_encoding())
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Implements the first phase of BFT consensus logic, focusing on basic proposal, voting, and Quorum Certificate (QC) formation.

Key changes:
- Defined `BftState` struct in `consensus/bft.rs` to manage BFT state, including:
    - `current_round`, `current_leader_pubkey`, `quorum_threshold`.
    - Maps for storing `prepare_votes`, `precommit_votes`, `commit_votes`.
    - Map for `known_qcs`.
    - `local_node_pubkey` for leader checks.
- Implemented methods on `BftState`:
    - `generate_proposal()`: Allows the current leader to create a `TriadProposal`. Includes basic validation of parent QC consistency.
    - `generate_vote()`: Allows a validator to generate a `VoteMessage` for a proposal after basic validation (round, parent QC).
    - `process_signed_vote()`: Stores votes, checks for duplicates (by signer for the same item/round/type), and forms/stores a `QuorumCertificate` when the threshold is met.
- Added `hash()` method to `TriadHeader` (in `triad/structs.rs`) for hashing headers, used in vote generation.
- Added comprehensive unit tests in `consensus/bft_test.rs` for:
    - `BftState` instantiation.
    - `generate_proposal()` logic (leader-only, valid/invalid inputs).
    - `generate_vote()` logic (valid/invalid proposals).
    - `process_signed_vote()` (vote accumulation, QC formation, duplicate vote handling).
- All tests pass and compiler warnings have been addressed.

This phase lays the groundwork for more complex BFT state transitions, signature verification, and full HotStuff protocol implementation.